### PR TITLE
Remove CRLF in favour of LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.bat text=auto eol=crlf


### PR DESCRIPTION
CRLF is bad so I removed it, and only allowed it to be in `*.bat` files